### PR TITLE
Using Nifty Counter Idiom for video source and target factory singletons

### DIFF
--- a/src/api/videosourcefactory.cpp
+++ b/src/api/videosourcefactory.cpp
@@ -34,7 +34,8 @@ VideoSourceFactory::~VideoSourceFactory()
 
 VideoSourceFactory & VideoSourceFactory::get_instance()
 {
-    return _factory_singleton;
+    static VideoSourceFactory _video_source_factory_singleton;
+    return _video_source_factory_singleton;
 }
 
 IVideoSource * VideoSourceFactory::get_device(Device device,

--- a/src/api/videosourcefactory.cpp
+++ b/src/api/videosourcefactory.cpp
@@ -18,8 +18,6 @@
 namespace gg
 {
 
-VideoSourceFactory VideoSourceFactory::_factory_singleton;
-
 VideoSourceFactory::VideoSourceFactory()
 {
     for (size_t i = 0; i < NUM_DEVICES; i++)

--- a/src/api/videosourcefactory.h
+++ b/src/api/videosourcefactory.h
@@ -24,14 +24,6 @@ namespace gg
 //!
 class VideoSourceFactory
 {
-protected:
-    //!
-    //! \brief The factory singleton object
-    //! that does the lifetime management of
-    //! all created video sources
-    //!
-    static VideoSourceFactory _factory_singleton;
-
     //!
     //! \brief So that can keep track of everything
     //! opened and in use
@@ -162,5 +154,12 @@ public:
 protected:
     DISALLOW_COPY_AND_ASSIGNMENT(VideoSourceFactory);
 };
+
+//!
+//! \brief The factory singleton object
+//! that does the lifetime management of
+//! all created video sources
+//!
+static VideoSourceFactory& _video_source_factory = VideoSourceFactory::get_instance();
 
 }

--- a/src/api/videotargetfactory.cpp
+++ b/src/api/videotargetfactory.cpp
@@ -9,8 +9,6 @@
 namespace gg
 {
 
-VideoTargetFactory VideoTargetFactory::_factory_singleton;
-
 VideoTargetFactory::VideoTargetFactory()
 {
     // nop
@@ -23,6 +21,7 @@ VideoTargetFactory::~VideoTargetFactory()
 
 VideoTargetFactory & VideoTargetFactory::get_instance()
 {
+    static VideoTargetFactory _factory_singleton;
     return _factory_singleton;
 }
 

--- a/src/api/videotargetfactory.cpp
+++ b/src/api/videotargetfactory.cpp
@@ -21,8 +21,8 @@ VideoTargetFactory::~VideoTargetFactory()
 
 VideoTargetFactory & VideoTargetFactory::get_instance()
 {
-    static VideoTargetFactory _factory_singleton;
-    return _factory_singleton;
+    static VideoTargetFactory _video_target_factory_singleton;
+    return _video_target_factory_singleton;
 }
 
 IVideoTarget * VideoTargetFactory::create_file_writer(enum Codec codec,

--- a/src/api/videotargetfactory.h
+++ b/src/api/videotargetfactory.h
@@ -23,12 +23,6 @@ class VideoTargetFactory
 {
 protected:
     //!
-    //! \brief The factory singleton object
-    //!
-    static VideoTargetFactory _factory_singleton;
-
-protected:
-    //!
     //! \brief The constructor should never
     //! be publicly called
     //! \sa get_instance
@@ -73,5 +67,10 @@ public:
 protected:
     DISALLOW_COPY_AND_ASSIGNMENT(VideoTargetFactory);
 };
+
+//!
+//! \brief The factory singleton object
+//!
+static VideoTargetFactory& _video_target_factory = VideoTargetFactory::get_instance();
 
 }

--- a/src/tests/pipeline/complex_pipeline.py
+++ b/src/tests/pipeline/complex_pipeline.py
@@ -50,8 +50,9 @@ class SnapshotSaver(IObserver):
             out_file = os.path.join(self.root_dir,
                                     'frame-{:010d}.png'.format(self.num_saved))
             data_uyvy = frame.data(False)
-            data_bgra = cv2.cvtColor(data_uyvy, cv2.COLOR_YUV2BGRA_UYVY)
-            scipy.misc.imsave(out_file, data_bgra)
+            data_uyvy = np.reshape(data_uyvy, (frame.rows(), frame.cols(), 2))
+            data_bgr = cv2.cvtColor(data_uyvy, cv2.COLOR_YUV2BGR_UYVY)
+            scipy.misc.imsave(out_file, data_bgr)
             self.last_saved = time()
 
 

--- a/src/tests/pipeline/run-complex-pipeline.sh
+++ b/src/tests/pipeline/run-complex-pipeline.sh
@@ -37,8 +37,9 @@ else
     ROOT_DIR=$CALL_DIR
 fi
 
+export BlackmagicSDK_DIR="/opt/blackmagic_sdk/10.11.1"
 BUILD_DIR=$ROOT_DIR/mtr-build
-CMAKE_OPTS="-D USE_FILES=ON"
+CMAKE_OPTS="-D USE_BLACKMAGIC_DECKLINK_SDI_4K=ON -D ENABLE_NONFREE=ON"
 CMAKE_OPTS="$CMAKE_OPTS -D USE_HEVC=ON"
 CMAKE_OPTS="$CMAKE_OPTS -D ENABLE_NONFREE=ON -D USE_NVENC=ON"
 CMAKE_OPTS="$CMAKE_OPTS -D BUILD_PYTHON=ON -D USE_NUMPY=ON"
@@ -72,7 +73,7 @@ do
     cd $WORKING_DIR
     RUN_LOG=$WORKING_DIR/run.log
     {
-        PYTHONPATH=$BUILD_DIR python $MTR_SCRIPT --input $1
+        PYTHONPATH=$BUILD_DIR python $MTR_SCRIPT
 
         exit_code=$?
         echo "Exit code was: $exit_code"


### PR DESCRIPTION
#19 seems to be caused by a [static init order fiasco](https://isocpp.org/wiki/faq/ctors#static-init-order).
As [recommended by the ISO C++ community](https://isocpp.org/wiki/faq/ctors#nifty-counter-idiom), using the Nifty Counter Idiom for implementing the Singleton design pattern for the video source and target factories seems to solve this problem.

* [x] The current #19 branch includes quick and dirty changes to the MTR scripts introduced as part of #16, which **should not** be merged.