### PR TITLE
Using Nifty Counter Idiom for video source and target factory singletons

### DIFF
--- a/src/api/videosourcefactory.cpp
+++ b/src/api/videosourcefactory.cpp
@@ -32,8 +32,8 @@ VideoSourceFactory::~VideoSourceFactory()
 
 VideoSourceFactory & VideoSourceFactory::get_instance()
 {
-    static VideoSourceFactory _video_source_factory_singleton;
-    return _video_source_factory_singleton;
+    static VideoSourceFactory video_source_factory;
+    return video_source_factory;
 }
 
 IVideoSource * VideoSourceFactory::get_device(Device device,

--- a/src/api/videosourcefactory.cpp
+++ b/src/api/videosourcefactory.cpp
@@ -34,7 +34,8 @@ VideoSourceFactory::~VideoSourceFactory()
 
 VideoSourceFactory & VideoSourceFactory::get_instance()
 {
-    return _factory_singleton;
+    static VideoSourceFactory _video_source_factory_singleton;
+    return _video_source_factory_singleton;
 }
 
 IVideoSource * VideoSourceFactory::get_device(Device device,

--- a/src/api/videosourcefactory.cpp
+++ b/src/api/videosourcefactory.cpp
@@ -18,8 +18,6 @@
 namespace gg
 {
 
-VideoSourceFactory VideoSourceFactory::_factory_singleton;
-
 VideoSourceFactory::VideoSourceFactory()
 {
     for (size_t i = 0; i < NUM_DEVICES; i++)

--- a/src/api/videosourcefactory.h
+++ b/src/api/videosourcefactory.h
@@ -24,6 +24,7 @@ namespace gg
 //!
 class VideoSourceFactory
 {
+protected:
     //!
     //! \brief So that can keep track of everything
     //! opened and in use

--- a/src/api/videosourcefactory.h
+++ b/src/api/videosourcefactory.h
@@ -24,14 +24,6 @@ namespace gg
 //!
 class VideoSourceFactory
 {
-protected:
-    //!
-    //! \brief The factory singleton object
-    //! that does the lifetime management of
-    //! all created video sources
-    //!
-    static VideoSourceFactory _factory_singleton;
-
     //!
     //! \brief So that can keep track of everything
     //! opened and in use
@@ -162,5 +154,12 @@ public:
 protected:
     DISALLOW_COPY_AND_ASSIGNMENT(VideoSourceFactory);
 };
+
+//!
+//! \brief The factory singleton object
+//! that does the lifetime management of
+//! all created video sources
+//!
+static VideoSourceFactory& _video_source_factory = VideoSourceFactory::get_instance();
 
 }

--- a/src/api/videotargetfactory.cpp
+++ b/src/api/videotargetfactory.cpp
@@ -9,8 +9,6 @@
 namespace gg
 {
 
-VideoTargetFactory VideoTargetFactory::_factory_singleton;
-
 VideoTargetFactory::VideoTargetFactory()
 {
     // nop
@@ -23,6 +21,7 @@ VideoTargetFactory::~VideoTargetFactory()
 
 VideoTargetFactory & VideoTargetFactory::get_instance()
 {
+    static VideoTargetFactory _factory_singleton;
     return _factory_singleton;
 }
 

--- a/src/api/videotargetfactory.cpp
+++ b/src/api/videotargetfactory.cpp
@@ -21,8 +21,8 @@ VideoTargetFactory::~VideoTargetFactory()
 
 VideoTargetFactory & VideoTargetFactory::get_instance()
 {
-    static VideoTargetFactory _factory_singleton;
-    return _factory_singleton;
+    static VideoTargetFactory _video_target_factory_singleton;
+    return _video_target_factory_singleton;
 }
 
 IVideoTarget * VideoTargetFactory::create_file_writer(enum Codec codec,

--- a/src/api/videotargetfactory.cpp
+++ b/src/api/videotargetfactory.cpp
@@ -21,8 +21,8 @@ VideoTargetFactory::~VideoTargetFactory()
 
 VideoTargetFactory & VideoTargetFactory::get_instance()
 {
-    static VideoTargetFactory _video_target_factory_singleton;
-    return _video_target_factory_singleton;
+    static VideoTargetFactory video_target_factory;
+    return video_target_factory;
 }
 
 IVideoTarget * VideoTargetFactory::create_file_writer(enum Codec codec,

--- a/src/api/videotargetfactory.h
+++ b/src/api/videotargetfactory.h
@@ -23,12 +23,6 @@ class VideoTargetFactory
 {
 protected:
     //!
-    //! \brief The factory singleton object
-    //!
-    static VideoTargetFactory _factory_singleton;
-
-protected:
-    //!
     //! \brief The constructor should never
     //! be publicly called
     //! \sa get_instance
@@ -73,5 +67,10 @@ public:
 protected:
     DISALLOW_COPY_AND_ASSIGNMENT(VideoTargetFactory);
 };
+
+//!
+//! \brief The factory singleton object
+//!
+static VideoTargetFactory& _video_target_factory = VideoTargetFactory::get_instance();
 
 }


### PR DESCRIPTION
#19 seems to be caused by a [static init order fiasco](https://isocpp.org/wiki/faq/ctors#static-init-order).
As [recommended by the ISO C++ community](https://isocpp.org/wiki/faq/ctors#nifty-counter-idiom), using the Nifty Counter Idiom for implementing the Singleton design pattern for the video source and target factories seems to solve this problem.

Closes #19 

These changes have been [tested with a device as well](https://gitlab.com/gift-surg/GIFT-Grab/pipelines/33547815) (#28)